### PR TITLE
LPUART Adjustments

### DIFF
--- a/src/stdstm32-uart.h
+++ b/src/stdstm32-uart.h
@@ -574,35 +574,59 @@ static inline void uart_rx_flush(void)
 // INIT routines
 //-------------------------------------------------------
 
-#if !(defined UART_USE_LPUART1 || defined UART_USE_LPUART1_REMAPPED) || defined STM32WL
-// for the moment, we don't support these functions for LPUART, except for WLE5xx
-
 void uart_setprotocol(uint32_t baud, UARTPARITYENUM parity, UARTSTOPBITENUM stopbits)
 {
-LL_USART_InitTypeDef USART_InitStruct = {0};
+#if defined(UART_USE_LPUART1) || defined(UART_USE_LPUART1_REMAPPED)
+	LL_LPUART_InitTypeDef LPUART_InitStruct = {0};
 
-  LL_USART_StructInit(&USART_InitStruct);
-  USART_InitStruct.BaudRate = baud;
-  USART_InitStruct.DataWidth = (parity != LL_USART_PARITY_NONE) ? LL_USART_DATAWIDTH_9B : LL_USART_DATAWIDTH_8B;
-  USART_InitStruct.StopBits = stopbits;
-  USART_InitStruct.Parity = parity;
-  USART_InitStruct.TransferDirection = LL_USART_DIRECTION_TX_RX;
-  LL_USART_Disable(UART_UARTx); // must be disabled to configure some registers
-  LL_USART_Init(UART_UARTx, &USART_InitStruct);
-  LL_USART_Enable(UART_UARTx);
+	  LL_LPUART_StructInit(&LPUART_InitStruct);
+	  LPUART_InitStruct.BaudRate = baud;
+	  LPUART_InitStruct.DataWidth = (parity != LL_USART_PARITY_NONE) ? LL_USART_DATAWIDTH_9B : LL_USART_DATAWIDTH_8B;
+	  LPUART_InitStruct.StopBits = stopbits;
+	  LPUART_InitStruct.Parity = parity;
+	  LPUART_InitStruct.TransferDirection = LL_LPUART_DIRECTION_TX_RX;
+	  LL_LPUART_Disable(UART_UARTx);
+	  LL_LPUART_Init(UART_UARTx, &LPUART_InitStruct);
+	  LL_LPUART_Enable(UART_UARTx);
+
+#else
+	LL_USART_InitTypeDef USART_InitStruct = {0};
+
+	  LL_USART_StructInit(&USART_InitStruct);
+	  USART_InitStruct.BaudRate = baud;
+	  USART_InitStruct.DataWidth = (parity != LL_USART_PARITY_NONE) ? LL_USART_DATAWIDTH_9B : LL_USART_DATAWIDTH_8B;
+	  USART_InitStruct.StopBits = stopbits;
+	  USART_InitStruct.Parity = parity;
+	  USART_InitStruct.TransferDirection = LL_USART_DIRECTION_TX_RX;
+	  LL_USART_Disable(UART_UARTx); // must be disabled to configure some registers
+	  LL_USART_Init(UART_UARTx, &USART_InitStruct);
+	  LL_USART_Enable(UART_UARTx);
+#endif
 }
 
 
 void uart_setbaudrate(uint32_t baud)
 {
-LL_USART_InitTypeDef USART_InitStruct = {0};
+#if defined(UART_USE_LPUART1) || defined(UART_USE_LPUART1_REMAPPED)
+	LL_LPUART_InitTypeDef LPUART_InitStruct = {0};
 
-  LL_USART_StructInit(&USART_InitStruct);
-  USART_InitStruct.BaudRate = baud;
-  USART_InitStruct.TransferDirection = LL_USART_DIRECTION_TX_RX;
-  LL_USART_Disable(UART_UARTx); // must be disabled to configure some registers
-  LL_USART_Init(UART_UARTx, &USART_InitStruct);
-  LL_USART_Enable(UART_UARTx);
+	  LL_LPUART_StructInit(&LPUART_InitStruct);
+	  LPUART_InitStruct.BaudRate = baud;
+	  LPUART_InitStruct.TransferDirection = LL_LPUART_DIRECTION_TX_RX;
+	  LL_LPUART_Disable(UART_UARTx);
+	  LL_LPUART_Init(UART_UARTx, &LPUART_InitStruct);
+	  LL_LPUART_Enable(UART_UARTx);
+
+#else
+	LL_USART_InitTypeDef USART_InitStruct = {0};
+
+	  LL_USART_StructInit(&USART_InitStruct);
+	  USART_InitStruct.BaudRate = baud;
+	  USART_InitStruct.TransferDirection = LL_USART_DIRECTION_TX_RX;
+	  LL_USART_Disable(UART_UARTx); // must be disabled to configure some registers
+	  LL_USART_Init(UART_UARTx, &USART_InitStruct);
+	  LL_USART_Enable(UART_UARTx);
+#endif
 }
 
 
@@ -616,8 +640,6 @@ void uart_tx_enable(FunctionalState flag)
   }
 #endif
 }
-
-#endif
 
 
 void uart_rx_enableisr(FunctionalState flag)


### PR DESCRIPTION
I spent some time going through the LPUART LL driver for STM32WL and STM32G4 and can't see any real differences in the files, G4 has the following changes:
- 50 Megabaud instead of 16 for STM32WL
- A couple functions use 'const USART_TypeDef *LPUARTx' whereas STM32WL uses 'USART_TypeDef *LPUARTx'

Links:

- https://github.com/olliw42/mLRS/blob/main/mLRS/rx-Wio-E5-Mini-wle5jc/Drivers/STM32WLxx_HAL_Driver/Src/stm32wlxx_ll_lpuart.c
- https://github.com/olliw42/mLRS/blob/main/mLRS/rx-diy-e22-g441kb/Drivers/STM32G4xx_HAL_Driver/Src/stm32g4xx_ll_lpuart.c

This updates the 'uart_setprotocol' and 'uart_setbaudrate' functions to use the LPUART structs and functions.  Verified working for CRSF output on STM32WL (E5 Mini) and STM32G4 (DIY 1 Watt)