### PR TITLE
stm32f1 spi1 remap

### DIFF
--- a/src/stdstm32-spi.h
+++ b/src/stdstm32-spi.h
@@ -517,6 +517,10 @@ LL_SPI_InitTypeDef SPI_InitStruct = {};
   LL_GPIO_AF_Remap_SWJ_NOJTAG();
 #endif
 
+#if defined SPI_USE_SPI1_PB3PB4PB5 && defined STM32F1
+  LL_GPIO_AF_EnableRemap_SPI1();
+#endif
+
 #ifndef SPI_USE_SUBGHZSPI
 
   // Configure pin CS

--- a/src/stdstm32-spi.h
+++ b/src/stdstm32-spi.h
@@ -513,12 +513,13 @@ LL_SPI_InitTypeDef SPI_InitStruct = {};
   subghz_init();
 #endif
 
-#if defined SPI_USE_SPI3 && defined STM32F1
+#if defined STM32F1
+#if defined SPI_USE_SPI1_PB3PB4PB5
+  LL_GPIO_AF_EnableRemap_SPI1();
+#endif
+#if defined SPI_USE_SPI3
   LL_GPIO_AF_Remap_SWJ_NOJTAG();
 #endif
-
-#if defined SPI_USE_SPI1_PB3PB4PB5 && defined STM32F1
-  LL_GPIO_AF_EnableRemap_SPI1();
 #endif
 
 #ifndef SPI_USE_SUBGHZSPI

--- a/src/stdstm32-spi.h
+++ b/src/stdstm32-spi.h
@@ -514,10 +514,10 @@ LL_SPI_InitTypeDef SPI_InitStruct = {};
 #endif
 
 #if defined STM32F1
-#if defined SPI_USE_SPI1_PB3PB4PB5
+#ifdef SPI_USE_SPI1_PB3PB4PB5
   LL_GPIO_AF_EnableRemap_SPI1();
 #endif
-#if defined SPI_USE_SPI3
+#ifdef SPI_USE_SPI3
   LL_GPIO_AF_Remap_SWJ_NOJTAG();
 #endif
 #endif

--- a/src/stdstm32-spib.h
+++ b/src/stdstm32-spib.h
@@ -513,8 +513,13 @@ LL_SPI_InitTypeDef SPI_InitStruct = {};
   subghz_init();
 #endif
 
-#if defined SPIB_USE_SPI3 && defined STM32F1
+#if defined STM32F1
+#if defined SPIB_USE_SPI1_PB3PB4PB5
+  LL_GPIO_AF_EnableRemap_SPI1();
+#endif
+#if defined SPIB_USE_SPI3
   LL_GPIO_AF_Remap_SWJ_NOJTAG();
+#endif
 #endif
 
 #ifndef SPIB_USE_SUBGHZSPI

--- a/src/stdstm32-spib.h
+++ b/src/stdstm32-spib.h
@@ -514,10 +514,10 @@ LL_SPI_InitTypeDef SPI_InitStruct = {};
 #endif
 
 #if defined STM32F1
-#if defined SPIB_USE_SPI1_PB3PB4PB5
+#ifdef SPIB_USE_SPI1_PB3PB4PB5
   LL_GPIO_AF_EnableRemap_SPI1();
 #endif
-#if defined SPIB_USE_SPI3
+#ifdef SPIB_USE_SPI3
   LL_GPIO_AF_Remap_SWJ_NOJTAG();
 #endif
 #endif

--- a/src/stdstm32-spic.h
+++ b/src/stdstm32-spic.h
@@ -514,10 +514,10 @@ LL_SPI_InitTypeDef SPI_InitStruct = {};
 #endif
 
 #if defined STM32F1
-#if defined SPIC_USE_SPI1_PB3PB4PB5
+#ifdef SPIC_USE_SPI1_PB3PB4PB5
   LL_GPIO_AF_EnableRemap_SPI1();
 #endif
-#if defined SPIC_USE_SPI3
+#ifdef SPIC_USE_SPI3
   LL_GPIO_AF_Remap_SWJ_NOJTAG();
 #endif
 #endif

--- a/src/stdstm32-spic.h
+++ b/src/stdstm32-spic.h
@@ -513,8 +513,13 @@ LL_SPI_InitTypeDef SPI_InitStruct = {};
   subghz_init();
 #endif
 
-#if defined SPIC_USE_SPI3 && defined STM32F1
+#if defined STM32F1
+#if defined SPIC_USE_SPI1_PB3PB4PB5
+  LL_GPIO_AF_EnableRemap_SPI1();
+#endif
+#if defined SPIC_USE_SPI3
   LL_GPIO_AF_Remap_SWJ_NOJTAG();
+#endif
 #endif
 
 #ifndef SPIC_USE_SUBGHZSPI

--- a/stdstm32-spi-template.h
+++ b/stdstm32-spi-template.h
@@ -513,8 +513,13 @@ LL_SPI_InitTypeDef SPI_InitStruct = {};
   subghz_init();
 #endif
 
-#if defined SPI$_USE_SPI3 && defined STM32F1
+#if defined STM32F1
+#if defined SPI$_USE_SPI1_PB3PB4PB5
+  LL_GPIO_AF_EnableRemap_SPI1();
+#endif
+#if defined SPI$_USE_SPI3
   LL_GPIO_AF_Remap_SWJ_NOJTAG();
+#endif
 #endif
 
 #ifndef SPI$_USE_SUBGHZSPI

--- a/stdstm32-spi-template.h
+++ b/stdstm32-spi-template.h
@@ -514,10 +514,10 @@ LL_SPI_InitTypeDef SPI_InitStruct = {};
 #endif
 
 #if defined STM32F1
-#if defined SPI$_USE_SPI1_PB3PB4PB5
+#ifdef SPI$_USE_SPI1_PB3PB4PB5
   LL_GPIO_AF_EnableRemap_SPI1();
 #endif
-#if defined SPI$_USE_SPI3
+#ifdef SPI$_USE_SPI3
   LL_GPIO_AF_Remap_SWJ_NOJTAG();
 #endif
 #endif


### PR DESCRIPTION
Allows remapped SPI1 pins on STM32F1 (needed for FRM303 with STM32F1 swap)